### PR TITLE
Adding SST to list of tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Also check out [Awesome AWS Amplify](https://github.com/dabit3/awesome-aws-ampli
 #### Serverless Framework
 - [GraphQL APIs with AWS AppSync (3 part series)](https://medium.com/@cbartling/graphql-apis-with-aws-appsync-part-one-bb441a5c2d9b)
 
+#### SST
+- [AWS AppSync with SST and Live Lambda Dev](https://serverless-stack.com/examples/how-to-create-a-serverless-graphql-api-with-aws-appsync.html)
+
 #### Performance and Monitoring
 - [Getting more visibility into GraphQL performance with AWS AppSync logs](https://aws.amazon.com/blogs/mobile/getting-more-visibility-into-graphql-performance-with-aws-appsync-logs)
 - [Tracing with AWS X-Ray](https://docs.aws.amazon.com/appsync/latest/devguide/x-ray-tracing.html)


### PR DESCRIPTION
Hi all,

Appreciate all the hard work!

I'm one of the creators of [SST](https://github.com/serverless-stack/serverless-stack), a framework for building serverless apps with CDK. We recently created a construct that makes it easy to deploy AppSync GraphQL APIs — https://serverless-stack.com/examples/how-to-create-a-serverless-graphql-api-with-aws-appsync.html. The added twist is that you can test and debug these live without having to redeploy. You can see it in action here:

https://www.youtube.com/watch?v=PScbA_1sYns

This PR adds a link to an example in the README.

Thank you!

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
